### PR TITLE
Infinite loop on `heroku logs --tail` retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Next Release
 ============
+* Fixed an infinite loop in the tail restart method used by `Heroku::Commander.run` with `detached: true` - [@macreery](https://github.com/macreery).
 * The `Heroku::Commander.run` with `detached: true` will now restart the tail process when aborted without having received a process exit message - [@dblock](https://github.com/dblock).
 * Added a `tail_retries` that defines the maximum number of tail restarts, default is 3 - [@dblock](https://github.com/dblock).
 

--- a/lib/heroku/runner.rb
+++ b/lib/heroku/runner.rb
@@ -130,9 +130,9 @@ module Heroku
               end
             end
           rescue
-            raise if tail_retries_left == 0
+            raise if tail_retries_left <= 0
           ensure
-            unless process_completed || tail_retries_left == 0
+            unless process_completed || tail_retries_left <= 0
               logger.debug "Restarting #{tail_cmdline}, #{tail_retries_left} #{tail_retries_left == 1 ? 'retry' : 'retries'} left." if logger
             end
           end

--- a/lib/heroku/runner.rb
+++ b/lib/heroku/runner.rb
@@ -130,9 +130,13 @@ module Heroku
               end
             end
           rescue
+            @running = false
             raise if tail_retries_left <= 0
           ensure
-            unless process_completed || tail_retries_left <= 0
+            if tail_retries_left <= 0
+              @running = false
+              raise
+            elsif !process_completed
               logger.debug "Restarting #{tail_cmdline}, #{tail_retries_left} #{tail_retries_left == 1 ? 'retry' : 'retries'} left." if logger
             end
           end


### PR DESCRIPTION
If a `heroku logs --tail` invocation succeeds (or exits with `Errno::EIO` or `IOError` instead of `PTY::ChildExited` on the second retry, we end up in an infinite loop, as demonstrated in the following logs from one of our apps:

```
21:04:05 Restarting heroku logs -p run.8151 --tail --app foobar-app, 1 retry left.
21:04:05 Running: heroku logs -p run.8151 --tail --app foobar-app
22:04:12 Started: 20226
22:04:12 Waiting: 20226
22:04:12 Running: heroku logs -p run.8151 --tail --app foobar-app
22:04:18 Started: 20253
22:04:18 Waiting: 20253
22:04:18 Restarting heroku logs -p run.8151 --tail --app foobar-app, -1 retries left.
22:04:18 Running: heroku logs -p run.8151 --tail --app foobar-app
23:04:24 Started: 20264
23:04:25 Waiting: 20264
23:04:25 Restarting heroku logs -p run.8151 --tail --app foobar-app, -2 retries left.
23:04:25 Running: heroku logs -p run.8151 --tail --app foobar-app
00:04:31 Started: 20300
00:04:31 Waiting: 20300
```

I'm happy to write a spec for this, but could use a recommendation on the best way to stub the causing behavior inside `Heroku::Executor`.
