### PR TITLE
@dblock => Add size=2x to the command line when you specify size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.3.1 (04/16/2013)
+==================
+* Fixed syntax error for heroku command-line, when specifying a `size` option - [@mzikherman](https://github.com/mzikherman).
+
 0.3.0 (04/15/2013)
 ==================
 * Fixed an infinite loop in the tail restart method used by `Heroku::Commander.run` with `detached: true` - [@macreery](https://github.com/macreery).

--- a/lib/heroku/runner.rb
+++ b/lib/heroku/runner.rb
@@ -61,7 +61,7 @@ module Heroku
       def cmdline(options = {})
         [
           "heroku", options[:detached] ? "run:detached" : "run",
-          @size ? "--size #{@size}" : nil,
+          @size ? "--size=#{@size}" : nil,
           "\"(#{command} 2>&1 ; echo rc=\\$?)\"",
           @app ? "--app #{@app}" : nil
         ].compact.join(" ")

--- a/spec/heroku/runner_spec.rb
+++ b/spec/heroku/runner_spec.rb
@@ -185,6 +185,6 @@ describe Heroku::Runner do
     subject do
       Heroku::Runner.new({ :command => "ls -1", size: "2X" })
     end
-    its(:cmdline) { should eq "heroku run --size 2X \"(ls -1 2>&1 ; echo rc=\\$?)\"" }
+    its(:cmdline) { should eq "heroku run --size=2X \"(ls -1 2>&1 ; echo rc=\\$?)\"" }
   end
 end


### PR DESCRIPTION
https://devcenter.heroku.com/articles/dyno-size

It looks like the syntax is '$ heroku run --size=2X rake heavy:job'. Just specifying --size 2x gives a syntax error.
